### PR TITLE
Add news: two papers accepted at MICRO 2026

### DIFF
--- a/news/_posts/2026-07-08-micro26-two-papers-accepted.md
+++ b/news/_posts/2026-07-08-micro26-two-papers-accepted.md
@@ -1,0 +1,19 @@
+---
+layout: news
+title: Two papers were accepted at <b><i>MICRO 2026 (top-tier conference)</i></b>.
+members:
+  - Daehoon Kim
+YYYY: "2026"
+MM: "07"
+DD: 
+sidebar:
+  - title: Publications
+    items:
+      - type: internal
+        url:
+        reveal: true
+      - type: internal
+        url: 
+        reveal: true
+alterlink: 
+---


### PR DESCRIPTION
Adds a news post announcing two papers accepted at MICRO 2026, following the format of the MICRO 2025 announcement.