### PR TITLE
Add MICRO 2026 publications (AMG, ReclaimX)

### DIFF
--- a/news/_posts/2026-07-08-micro26-two-papers-accepted.md
+++ b/news/_posts/2026-07-08-micro26-two-papers-accepted.md
@@ -10,10 +10,10 @@ sidebar:
   - title: Publications
     items:
       - type: internal
-        url:
+        url: /publications/micro26-mkim/
         reveal: true
       - type: internal
-        url: 
+        url: /publications/micro26-sbang/
         reveal: true
 alterlink: 
 ---

--- a/publications/_posts/2026-07-08-micro26-mkim.md
+++ b/publications/_posts/2026-07-08-micro26-mkim.md
@@ -1,0 +1,38 @@
+---
+layout: publication
+title: "AMG: AMX–GPU Cooperative Acceleration of Billion-Scale ANNS via GEMM Reformulation"
+image: 
+authors:
+  - name: Minho Kim
+  - name: Houxiang Ji
+  - name: Hwanjun Lee
+  - name: Jaeyoung Kang
+  - name: Sungju Kim
+  - name: Hyunkyun Shin
+  - name: Daehoon Kim
+    corresponding: true
+  - name: Nam Sung Kim
+co-first: false
+type: Paper
+international: true
+paper:
+  year: 2026
+  publisher: "IEEE/ACM International Symposium on Microarchitecture"
+  publisher-short: MICRO
+  publisher-type: Conference
+  ref: 
+publication_tags:
+  - TOP-Tier
+publication_fields:
+  - AI System
+researches: [AI Systems]
+keywords:
+  - ANNS
+  - AMX
+  - GPU
+  - GEMM
+doi: 
+sidebar:
+components: [abstract, keywords, topics]
+hidden: false
+---

--- a/publications/_posts/2026-07-08-micro26-sbang.md
+++ b/publications/_posts/2026-07-08-micro26-sbang.md
@@ -1,0 +1,36 @@
+---
+layout: publication
+title: "ReclaimX: Device-Side Memory Reclamation via Stalled GPU Execution for UVM Oversubscription"
+image: 
+authors:
+  - name: Seongtae Bang
+  - name: Hyunkyun Shin
+  - name: Hyungwon Park
+  - name: Minho Kim
+  - name: Daehoon Kim
+    corresponding: true
+co-first: false
+type: Paper
+international: true
+paper:
+  year: 2026
+  publisher: "IEEE/ACM International Symposium on Microarchitecture"
+  publisher-short: MICRO
+  publisher-type: Conference
+  ref: 
+publication_tags:
+  - TOP-Tier
+publication_fields:
+  - GPU
+  - Next-Gen Memory System
+researches: [GPU, memory]
+keywords:
+  - GPU
+  - UVM
+  - Memory Oversubscription
+  - Memory Reclamation
+doi: 
+sidebar:
+components: [abstract, keywords, topics]
+hidden: false
+---


### PR DESCRIPTION
Adds publication pages for the two MICRO 2026 papers (AMG, ReclaimX) and links them from the news post sidebar.