### PR TITLE
Remove trailing period after last author in publication lists

### DIFF
--- a/_includes/pub_ref.html
+++ b/_includes/pub_ref.html
@@ -20,9 +20,9 @@
   {% if forloop.last and forloop.length > 1 and short != true %}and {% endif %}
   {% if linked %}
       <a href="{{ mem_url }}"{% if newtab == true %} target="_blank" rel="noopener noreferrer"{% endif %}>
-    {{ name }}</a>{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{% if co-first-now %} [co-first author]{% endif %}{% if forloop.last %}.{% else %}, {% endif %}
+    {{ name }}</a>{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{% if co-first-now %} [co-first author]{% endif %}{% unless forloop.last %}, {% endunless %}
   {% else %}
-    {{ name }}{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{% if co-first-now %} [co-first author]{% endif %}{% if forloop.last %}.{% else %}, {% endif %}
+    {{ name }}{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{% if co-first-now %} [co-first author]{% endif %}{% unless forloop.last %}, {% endunless %}
   {% endif %}
 {% endfor %}
 

--- a/_includes/pub_ref_name.html
+++ b/_includes/pub_ref_name.html
@@ -18,8 +18,8 @@
   {%- endif -%}
   {%- if forloop.last and forloop.length > 1 and short != true -%}and {% endif -%}
   {%- if linked -%}
-      <a href="{{ mem_url }}"{% if newtab == true %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ name }}</a>{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{%- if co-first-now -%} [co-first author]{%- endif -%}{%- if forloop.last -%}.{%- else -%}, {% endif -%}
+      <a href="{{ mem_url }}"{% if newtab == true %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ name }}</a>{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{%- if co-first-now -%} [co-first author]{%- endif -%}{%- unless forloop.last -%}, {% endunless -%}
   {%- else -%}
-    {{ name }}{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{%- if co-first-now -%} [co-first author]{%- endif -%}{%- if forloop.last -%}.{%- else -%}, {% endif -%}
+    {{ name }}{%- if author.corresponding -%}<span title="Corresponding Author" class="corresponding"><sup>*</sup></span>{%- endif -%}{%- if co-first-now -%} [co-first author]{%- endif -%}{%- unless forloop.last -%}, {% endunless -%}
   {%- endif -%}
 {%- endfor -%}


### PR DESCRIPTION
Publication entries are rendered as a card-style list (title / authors / venue on separate lines), so the trailing period after the last author was the only terminal punctuation and looked inconsistent. This removes it in both the full and short author-list templates. Member name lists used in prose (member_ref.html) are unchanged.