### PR TITLE
Remove Cloud field from nine network/power publications

### DIFF
--- a/publications/_posts/2010-09-11-pact10-dkim.md
+++ b/publications/_posts/2010-09-11-pact10-dkim.md
@@ -23,7 +23,6 @@ publication_tags:
   - TOP-Tier
 publication_fields:
   - Architecture
-  - Cloud
 researches: 
   - memory
 keywords:

--- a/publications/_posts/2017-05-08-hpca17-malian.md
+++ b/publications/_posts/2017-05-08-hpca17-malian.md
@@ -27,7 +27,6 @@ publication_tags:
   - TOP-Tier
 publication_fields:
   - Power/Resource Management
-  - Cloud
 researches: [power]
 keywords:
   - Power management

--- a/publications/_posts/2017-07-13-ispass17-malian.md
+++ b/publications/_posts/2017-07-13-ispass17-malian.md
@@ -27,7 +27,6 @@ publication_tags:
   - Major
 publication_fields:
   - Architecture
-  - Cloud
 researches: 
 keywords:
   - Distributed computer systems

--- a/publications/_posts/2019-07-01-cal20-kdkang.md
+++ b/publications/_posts/2019-07-01-cal20-kdkang.md
@@ -24,7 +24,6 @@ publication_tags:
   - SCI
 publication_fields:
   - Power/Resource Management
-  - Cloud
 researches: [power]
 keywords:
   - Power management

--- a/publications/_posts/2020-11-04-access20-kdkang-hpark.md
+++ b/publications/_posts/2020-11-04-access20-kdkang-hpark.md
@@ -25,7 +25,6 @@ publication_tags:
   - SCI
 publication_fields:
   - Power/Resource Management
-  - Cloud
 researches: [power]
 keywords:
   - Power management

--- a/publications/_posts/2020-12-15-cal21-malian-jshin.md
+++ b/publications/_posts/2020-12-15-cal21-malian-jshin.md
@@ -22,7 +22,7 @@ authors:
 co-first: true
 type: Paper
 international: true
-researches: [memory, cloud]
+researches: [memory]
 keywords:
   - Inbound network data placement
   - Memory hierarchy optimization
@@ -38,7 +38,6 @@ paper: # delete if patent
 publication_tags:
   - SCI
 publication_fields:
-  - Cloud
   - Architecture
 sidebar:
 doi: 10.1109/LCA.2020.3044923

--- a/publications/_posts/2020-12-21-iccd20-kdkang-hpark.md
+++ b/publications/_posts/2020-12-21-iccd20-kdkang-hpark.md
@@ -32,7 +32,6 @@ publication_tags:
   - Major
 publication_fields:
   - Power/Resource Management
-  - Cloud
 sidebar:
 doi: 10.1109/ICCD50377.2020.00069
 components: [abstract, keywords, topics]

--- a/publications/_posts/2021-10-17-micro21-kdkang.md
+++ b/publications/_posts/2021-10-17-micro21-kdkang.md
@@ -32,7 +32,6 @@ paper:
 publication_tags:
   - TOP-Tier
 publication_fields:
-  - Cloud
   - Power/Resource Management
 sidebar:
 doi: 10.1145/3466752.3480098

--- a/publications/_posts/2022-10-26-micro22-malian.md
+++ b/publications/_posts/2022-10-26-micro22-malian.md
@@ -39,6 +39,7 @@ paper:
 publication_tags:
   - TOP-Tier
 publication_fields:
+  - Architecture
 sidebar:
 doi: 10.1109/MICRO56248.2022.00042
 components: [abstract, keywords, topics]

--- a/publications/_posts/2022-10-26-micro22-malian.md
+++ b/publications/_posts/2022-10-26-micro22-malian.md
@@ -20,7 +20,7 @@ authors:
 co-first: false
 type: Paper
 international: true
-researches: [memory, cloud]
+researches: [memory]
 keywords:
   - Inbound network data orchestration
   - Cache hierarchy optimization
@@ -39,7 +39,6 @@ paper:
 publication_tags:
   - TOP-Tier
 publication_fields:
-  - Cloud
 sidebar:
 doi: 10.1109/MICRO56248.2022.00042
 components: [abstract, keywords, topics]


### PR DESCRIPTION
Removes the Cloud publication field (and the cloud research topic where present) from nine papers: Subspace Snooping (PACT10), NCAP, dist-gem5, CAL20 packet-mode PM, Co-Adjusting V/F (ACCESS20), IDIO (CAL21), ICCD20 interrupt PM, NMAP (MICRO21), IDIO (MICRO22). Note: the MICRO22 IDIO entry now has no publication field.