### PR TITLE
Use vertical bar separator for Open Positions list on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ categories:
    <h3 style="text-align: center; color: #003876; margin-top: 0;">[Recruitment] Graduate Students for Spring 2027</h3>
    <h4 style="margin-bottom: 0.5em;">■ Open Positions</h4>
    <p style="margin-top: 0; margin-bottom: 1.5em;">
-     M.S. Program / Ph.D. Program / Integrated M.S./Ph.D. Program<br>
+     M.S. Program&ensp;|&ensp;Ph.D. Program&ensp;|&ensp;Integrated M.S./Ph.D. Program<br>
      <span style="font-size: 0.9em; color: #555;"><em>* We are also actively looking for undergraduate interns.</em></span>
    </p>
    <h4 style="margin-bottom: 0.5em;">■ Affiliated Departments</h4>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ categories:
    <h3 style="text-align: center; color: #003876; margin-top: 0;">[Recruitment] Graduate Students for Spring 2027</h3>
    <h4 style="margin-bottom: 0.5em;">■ Open Positions</h4>
    <p style="margin-top: 0; margin-bottom: 1.5em;">
-     M.S. Program&ensp;|&ensp;Ph.D. Program&ensp;|&ensp;Integrated M.S./Ph.D. Program<br>
+     M.S. Program / Ph.D. Program / Integrated M.S.&ndash;Ph.D. Program<br>
      <span style="font-size: 0.9em; color: #555;"><em>* We are also actively looking for undergraduate interns.</em></span>
    </p>
    <h4 style="margin-bottom: 0.5em;">■ Affiliated Departments</h4>

--- a/news/_posts/2025-10-21-dkim-micro-hall-of-fame.md
+++ b/news/_posts/2025-10-21-dkim-micro-hall-of-fame.md
@@ -1,6 +1,6 @@
 ---
 layout: news
-title: Prof. Daehoon Kim was inducted into the <b><i><a href="https://www.sigmicro.org/awards/microhof.php" target="_blank">MICRO Hall of Fame</a></i></b>
+title: Prof. Daehoon Kim was inducted into the <b><i><a href="https://www.sigmicro.org/awards/microhof.php" target="_blank">MICRO Hall of Fame</a></i></b>.
 members:
   - Daehoon Kim
 YYYY: "2025"


### PR DESCRIPTION
The slash separators in "M.S. Program / Ph.D. Program / Integrated M.S./Ph.D. Program" visually collided with the slash inside "M.S./Ph.D.". Replaced the list separators with vertical bars (with en-space padding) so the internal slash stays unambiguous.