### PR TITLE
Add CAL 2026 paper BlockPIM (news + publication)

### DIFF
--- a/news/_posts/2026-07-13-cal26-accepted.md
+++ b/news/_posts/2026-07-13-cal26-accepted.md
@@ -1,0 +1,14 @@
+---
+layout: news
+title: Our paper was accepted at <b><i>IEEE CAL (SCI(E) journal)</i></b>.
+members:
+  - Seulki Kim
+  - Yewon Jang
+  - Yunhyeong Jeon
+  - Kyeonghyeon Ryu
+  - Daehoon Kim
+YYYY: "2026"
+MM: "07"
+DD: 
+alterlink: /publications/cal26-skim/
+---

--- a/publications/_posts/2026-07-13-cal26-skim.md
+++ b/publications/_posts/2026-07-13-cal26-skim.md
@@ -1,0 +1,32 @@
+---
+layout: publication
+title: "BlockPIM: Enabling Sparse LLM Inference on Dense PIM Architectures"
+image:
+authors:
+  - name: Seulki Kim
+  - name: Yewon Jang
+  - name: Yunhyeong Jeon
+  - name: Kyeonghyeon Ryu
+  - name: Daehoon Kim
+    corresponding: true
+co-first: false
+type: Paper
+international: true
+researches: [AI, Memory]
+keywords:
+  - Processing-in-Memory, Sparse LLM Inference, Large Language Model Inference
+paper:
+  year: 2026
+  publisher: "IEEE Computer Architecture Letters"
+  publisher-short: "CAL"
+  publisher-type: Journal
+publication_tags:
+  - SCI
+publication_fields:
+  - AI System
+  - Next-Gen Memory System
+sidebar:
+doi:
+components: [abstract, keywords, topics]
+hidden: false
+---


### PR DESCRIPTION
Adds the IEEE CAL 2026 accepted paper BlockPIM: Enabling Sparse LLM Inference on Dense PIM Architectures (Seulki Kim, Yewon Jang, Yunhyeong Jeon, Kyeonghyeon Ryu, Daehoon Kim). News post + publication page. Abstract and DOI left empty pending final info.