### PR TITLE
news: show month only for Hyosang Kim defence

### DIFF
--- a/news/_posts/2026-05-15-hkim-defended-doctoral-thesis.md
+++ b/news/_posts/2026-05-15-hkim-defended-doctoral-thesis.md
@@ -5,7 +5,7 @@ members:
   - Hyosang Kim
 YYYY: "2026"
 MM: "05"
-DD: "15"
+DD: 
 sidebar:
 alterlink: 
 ---


### PR DESCRIPTION
Follow-up to #217. Blanks the DD field so the Hyosang Kim defence news shows month only (2026-05), matching the CAL accepted posts. The month-only change did not make it into #217 because that PR was already merged before the fix was pushed.