### PR TITLE
recruitment: reword M.S. note to M.S. admissions closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ categories:
    <h4 style="margin-bottom: 0.5em;">■ Open Positions</h4>
    <p style="margin-top: 0; margin-bottom: 1.5em;">
      Ph.D. / Integrated M.S.&ndash;Ph.D. Programs<br>
-     <s style="color: #999;">M.S. Program</s> <span style="font-size: 0.85em; color: #888;">(no longer accepting applications)</span><br>
+     <s style="color: #999;">M.S. Program</s> <span style="font-size: 0.85em; color: #888;">(M.S. admissions closed)</span><br>
      <span style="font-size: 0.9em; color: #555;"><em>* We are also actively looking for undergraduate interns.</em></span>
    </p>
    <h4 style="margin-bottom: 0.5em;">■ Affiliated Departments</h4>


### PR DESCRIPTION
Replaces the note next to the struck-through M.S. Program with (M.S. admissions closed) - shorter and unambiguous on its own.