### PR TITLE
Add CAL 2026 paper ResidualEvil (news + publication)

### DIFF
--- a/news/_posts/2026-07-26-cal26-accepted.md
+++ b/news/_posts/2026-07-26-cal26-accepted.md
@@ -1,0 +1,13 @@
+---
+layout: news
+title: Our paper was accepted at <b><i>IEEE CAL (SCI(E) journal)</i></b>.
+members:
+  - Minwoo Jang
+  - Hyosang Kim
+  - Sungju Kim
+  - Daehoon Kim
+YYYY: "2026"
+MM: "07"
+DD: 
+alterlink: /publications/cal26-2-mjang/
+---

--- a/publications/_posts/2026-07-26-cal26-2-mjang.md
+++ b/publications/_posts/2026-07-26-cal26-2-mjang.md
@@ -1,0 +1,32 @@
+---
+layout: publication
+title: "ResidualEvil: Exploiting Post-Squash MSHR Contention for Transient Execution Attacks"
+image:
+authors:
+  - name: Minwoo Jang
+  - name: Hyosang Kim
+  - name: Sungju Kim
+  - name: Daehoon Kim
+    corresponding: true
+co-first: false
+type: Paper
+international: true
+researches: [security]
+keywords:
+  - Security
+  - Transient Execution Attacks
+  - Microarchitectural Side Channel, MSHR Contention
+paper:
+  year: 2026
+  publisher: "IEEE Computer Architecture Letters"
+  publisher-short: "CAL"
+  publisher-type: Journal
+publication_tags:
+  - SCI
+publication_fields:
+  - Security
+sidebar:
+doi:
+components: [abstract, keywords, topics]
+hidden: false
+---


### PR DESCRIPTION
Adds the IEEE CAL 2026 accepted paper ResidualEvil: Exploiting Post-Squash MSHR Contention for Transient Execution Attacks (Minwoo Jang, Hyosang Kim, Sungju Kim, Daehoon Kim corresponding). News post + publication page (field: Security; SCI). Slug cal26-2-mjang to avoid collision with the existing March cal26-mjang. Abstract and DOI left empty pending final info.