### PR TITLE
recruitment: reorder Integrated M.S.-Ph.D. first and shorten hyphen

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ categories:
    <h3 style="text-align: center; color: #003876; margin-top: 0;">[Recruitment] Graduate Students for Spring 2027</h3>
    <h4 style="margin-bottom: 0.5em;">■ Open Positions</h4>
    <p style="margin-top: 0; margin-bottom: 1.5em;">
-     Ph.D. / Integrated M.S.&ndash;Ph.D. Programs<br>
+     Integrated M.S.-Ph.D. / Ph.D. Programs<br>
      <s style="color: #999;">M.S. Program</s> <span style="font-size: 0.85em; color: #888;">(M.S. admissions closed)</span><br>
      <span style="font-size: 0.9em; color: #555;"><em>* We are also actively looking for undergraduate interns.</em></span>
    </p>


### PR DESCRIPTION
Puts Integrated M.S.-Ph.D. before Ph.D. in Open Positions, and replaces the en dash (&ndash;) between M.S. and Ph.D. with a plain hyphen.